### PR TITLE
Add base compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ specific dependencies please visit the single package's documentation:
 - [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) >= `v0.11.11`
 - [Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) >= `v1.11.7`
 
+## Compatibility
+
+| Distribution Version / Kubernetes Version | 1.11.X             | 1.12.X             | 1.13.X             | 1.14.X             | 1.15.X             | 1.16.X             |
+|-------------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| v1.11.6                                   | :white_check_mark: |                    |                    |                    |                    |                    |
+
+- :white_check_mark: Compatible
+- :warning: Has issues
+- :x: Incompatible
+
 ## Examples
 
 To see examples on how to customize Fury distribution with kustomize please go to [examples](examples)


### PR DESCRIPTION
Hi team.

I will open this pull request to start adding information about the compatibility of this kind of repositories/distribution with the upstream kubernetes versions.

After this series of PR's i will open an internal discussion about the branching model (release process).

The scope of this PR it's just to add the base structure to publish our compatibility with the upstream kubernetes version.

Thanks!