### PR TITLE
Add support for cert-manager webhooks

### DIFF
--- a/modules/gke-private/input.tf
+++ b/modules/gke-private/input.tf
@@ -79,3 +79,9 @@ variable "bastion-vpn-enabled" {
   default     = true
   description = "disabling this will block all the INGRESS traffic on port 1194 of the bastion instances"
 }
+
+variable "cert-manager-support" {
+  type        = "string"
+  default     = false
+  description = "enabling this will open traffic from GKE masters to GKE workers on port 6443 where cert-manager webhook runs"
+}

--- a/modules/gke-private/network.tf
+++ b/modules/gke-private/network.tf
@@ -55,3 +55,19 @@ resource "google_compute_firewall" "nodes" {
   target_tags = ["${var.env}"]
   source_tags = ["${var.env}"]
 }
+
+// THIS RULE IS REQUIRED FOR MASTER NODES TO ACCESS CERT-MANAGER WEBHOOK ON THE NODES
+resource "google_compute_firewall" "cert-webhook" {
+  count         = "${var.cert-manager-support}" ? "1" : "0"
+  name          = "${var.name}-${var.env}-cert-webhook"
+  network       = "${var.network}"
+  direction     = "INGRESS"
+
+  allow {
+    protocol = "TCP"
+    ports    = ["6443"]
+  }
+
+  target_tags   = ["internal-${var.env}"]
+  source_ranges = ["${var.master_cidr}"]
+}


### PR DESCRIPTION
Cert-manager webhooks listen for traffic from master on GKE worker nodes
on port 6443. This commit adds a support for creating necessary firewall
rules in order to allow this traffic through.